### PR TITLE
Disable modification of a note's subject when updating

### DIFF
--- a/public/test/note/edit.test.js
+++ b/public/test/note/edit.test.js
@@ -49,11 +49,12 @@ describe('noteEdit', function() {
     });
 
     describe('updateNote', () => {
-        it('should update the Note then redirect to note detail page if success', () => {
+        it('should update the body of Note only then redirect to note detail page if success', () => {
             Note.update.and.returnValue({
                 $promise: $q.when(),
             });
 
+            ctrl.note.subject = 'new subject';
             ctrl.note.body = 'new body';
 
             ctrl.updateNote();
@@ -63,7 +64,7 @@ describe('noteEdit', function() {
             expect(Note.update).toHaveBeenCalledWith({
                 id: 56,
             }, {
-                body: 'new body',
+                body: 'new body'
             });
 
             expect($location.path).toHaveBeenCalledWith('/notes/56');

--- a/test/api/route/note.test.js
+++ b/test/api/route/note.test.js
@@ -86,6 +86,19 @@ describe('Tests for api route note', () => {
             req.note.update.calledWithExactly('some body').should.be.true();
             res.json.calledWithExactly('exposedNote').should.be.true();
         });
+
+        it('should not update a subject', async () => {
+            req.note = note;
+
+            req.body = {
+                subject: 'some subject',
+                body: 'some body',
+            };
+
+            await route.note.update(req, res);
+            req.note.update.calledWithExactly(req.body.body).should.be.true();//should only use the value stores in req.body.body
+            res.json.calledWithExactly('exposedNote').should.be.true();
+        });
     });
 
     describe('delete', () => {

--- a/test/domain/note.test.js
+++ b/test/domain/note.test.js
@@ -54,6 +54,13 @@ describe('Tests for domain Note', () => {
                     updatedAt: _.isDate,
                 });
             });
+
+            it('should not update the subject of the note', async () => {
+                await domainNote.update({
+                    subject: 'new subject',
+                    body: 'updated body'
+                }).should.be.rejectedWith(model.sequelize.ValidationError);
+            });
         });
 
         describe('delete', () => {


### PR DESCRIPTION
Found **no bug** that allows the modification of a note's subject. The body field of a note is always specifically passed preventing other fields, including subject, to be accidentally updated.

Findings:
1. In the event that a user is able to manipualte the UI, the **updateNote()** only uses **note.body** as update parameter.

**/public/src/note/edit.js line 14 to 18:** 
`
                Note.update({
                    id: this.note.id
                }, {
                    body: this.note.body
                })
`

2. Passing a subject to `PUT /api/notes/:noteId` endpoint may update a note's subject but the body is the only one used as the update parameter.

**/src/api/route/note.js line 19 to 22:**
`module.exports.update = async (req, res) => {
    await req.note.update(req.body.body);
    res.json(req.note.expose());
};`


3. Passing a note object to the domain update is another possibility. In this scenario, when an object is passed, it will be converted to body's value and will generate SequelizeValidationError.


**/src/domain/note.js line 23 to 27**
`    async update(body) {
        await this._note.update({
            body
        });
    }`