### PR TITLE
Added Note Versioning

### DIFF
--- a/public/src/note/detail.html
+++ b/public/src/note/detail.html
@@ -6,6 +6,10 @@
 </ol>
 
 <p class="clearfix">
+    <select class="form-control form-control-lg" ng-model="$ctrl.display" onchange="">
+        <option ng-value="$ctrl.note" ng-bind="$ctrl.note.version"></option>
+        <option ng-repeat="version in $ctrl.versions" ng-value="version" ng-bind="version.version"></option>
+    </select>
     <a class="btn btn-default pull-right" ng-href="#!/notes/{{ $ctrl.note.id }}/edit">Edit</a>
 </p>
 
@@ -14,7 +18,7 @@
         <h3 class="panel-title" ng-bind="$ctrl.note.subject"></h3>
     </div>
 
-    <div class="panel-body" style="white-space: pre-wrap;" ng-bind="$ctrl.note.body"></div>
+    <div class="panel-body" style="white-space: pre-wrap;" ng-bind="$ctrl.display.body"></div>
 
     <div class="panel-footer" ng-bind="$ctrl.note.updatedAt | date:'medium'"></div>
 </div>

--- a/public/src/note/detail.html
+++ b/public/src/note/detail.html
@@ -5,13 +5,20 @@
     <li class="active" ng-bind="$ctrl.note.subject"></li>
 </ol>
 
-<p class="clearfix">
-    <select class="form-control form-control-lg" ng-model="$ctrl.display" onchange="">
-        <option ng-value="$ctrl.note" ng-bind="$ctrl.note.version"></option>
-        <option ng-repeat="version in $ctrl.versions" ng-value="version" ng-bind="version.version"></option>
-    </select>
-    <a class="btn btn-default pull-right" ng-href="#!/notes/{{ $ctrl.note.id }}/edit">Edit</a>
-</p>
+
+<div class="form-group row align-items-center">
+    <div class="col-md-9"></div>
+    <label for="version" class="col-sm-1 col-form-label" style="line-height: 34px; text-align: right; padding: 0;">Version</label>
+    <div class="col-sm-1 offset-md-3">
+        <select class="form-control form-control-lg" ng-model="$ctrl.display">
+            <option ng-value="$ctrl.note" ng-bind="$ctrl.note.version"></option>
+            <option ng-repeat="version in $ctrl.versions" ng-value="version" ng-bind="version.version"></option>
+        </select>
+    </div>
+    <div class="col-sm-1">
+        <a class="btn btn-default" ng-href="#!/notes/{{ $ctrl.note.id }}/edit">Edit</a>
+    </div>
+</div>
 
 <div class="panel panel-default">
     <div class="panel-heading">

--- a/public/src/note/detail.js
+++ b/public/src/note/detail.js
@@ -5,5 +5,11 @@ angular.module('app').component('noteDetail', {
     bindings: {
         session: '<',
         note: '<',
+        versions: '<'
+    },
+    controller: function(Version) {
+        this.$onInit = function() {
+            this.display = this.note;
+        };
     },
 });

--- a/public/src/note/detail.js
+++ b/public/src/note/detail.js
@@ -7,7 +7,7 @@ angular.module('app').component('noteDetail', {
         note: '<',
         versions: '<'
     },
-    controller: function(Version) {
+    controller: function() {
         this.$onInit = function() {
             this.display = this.note;
         };

--- a/public/src/resources/version.js
+++ b/public/src/resources/version.js
@@ -1,0 +1,5 @@
+'use strict';
+
+angular.module('app').factory('Version', function($resource) {
+    return $resource('/api/notes/:noteId/versions/:versionId', {}, {});
+});

--- a/public/src/routes.js
+++ b/public/src/routes.js
@@ -31,11 +31,14 @@ angular.module('app').config(function($routeProvider) {
     };
 
     const noteDetailPage = {
-        template: '<note-detail session="$resolve.session" note="$resolve.note"></note-detail>',
+        template: '<note-detail session="$resolve.session" note="$resolve.note" versions="$resolve.versions"></note-detail>',
         resolve: {
             session: Session => Session.current().$promise,
             note: (Note, $route) => Note.get({
                 id: $route.current.params.noteId
+            }).$promise,
+            versions: (Version, $route) => Version.query({
+                noteId: $route.current.params.noteId
             }).$promise
         }
     };

--- a/public/test/note/detail.test.js
+++ b/public/test/note/detail.test.js
@@ -35,7 +35,6 @@ describe('noteDetail', function() {
 
     describe('$onInit', () => {
         it('should set display to notes', () => {
-            console.log(ctrl);
             ctrl.$onInit();
 
             expect(ctrl.display).toEqual(note);

--- a/public/test/note/detail.test.js
+++ b/public/test/note/detail.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+describe('noteDetail', function() {
+    let $componentController;
+    let ctrl;
+    let Note;
+    /* let Session; */
+    let note;
+
+    beforeEach(() => {
+        module('app');
+
+        inject((_$componentController_, _Note_, _Session_, _$route_, _$q_, _$rootScope_) => {
+            $componentController = _$componentController_;
+            Note = _Note_;
+            /* Session = _Session_;
+            $route = _$route_;
+            $q = _$q_;
+            $rootScope = _$rootScope_; */
+        });
+
+        /* spyOn(Note, 'delete');
+        spyOn(Session, 'current'); */
+
+        note = new Note({
+            id: 56,
+            subject: 'some subject',
+            body: 'some body',
+        });
+
+        ctrl = $componentController('noteDetail', {}, {
+            note
+        });
+    });
+
+    describe('$onInit', () => {
+        it('should set display to notes', () => {
+            console.log(ctrl);
+            ctrl.$onInit();
+
+            expect(ctrl.display).toEqual(note);
+        });
+
+    });
+});

--- a/public/test/routes.test.js
+++ b/public/test/routes.test.js
@@ -8,22 +8,25 @@ describe('routes', function() {
     let Session;
     let Note;
     let path;
+    let Version;
 
     beforeEach(() => {
         module('app');
 
-        inject((_$q_, _$rootScope_, _$route_, _$location_, _Session_, _Note_) => {
+        inject((_$q_, _$rootScope_, _$route_, _$location_, _Session_, _Note_, _Version_) => {
             $q = _$q_;
             $rootScope = _$rootScope_;
             $route = _$route_;
             $location = _$location_;
             Session = _Session_;
             Note = _Note_;
+            Version = _Version_;
         });
 
         spyOn(Session, 'current');
         spyOn(Note, 'query');
         spyOn(Note, 'get');
+        spyOn(Version, 'query');
     });
 
     function resolveCurrentSession(done) {
@@ -98,6 +101,23 @@ describe('routes', function() {
             expect(Note.get).toHaveBeenCalledWith({
                 id: ':noteId'
             });
+
+            done();
+        }).catch(reason => {
+            fail(`Should not reject: ${ reason }`);
+            done();
+        });
+
+        $rootScope.$digest();
+    }
+
+    function resolveVersions(done) {
+        Version.query.and.returnValue({
+            $promise: $q.when('versions'),
+        });
+
+        $route.current.resolve.versions(Version, $route).then(versions => {
+            expect(versions).toEqual('versions');
 
             done();
         }).catch(reason => {
@@ -209,6 +229,14 @@ describe('routes', function() {
             $rootScope.$digest();
 
             resolveNote(done);
+        });
+
+        it('should resolve version', done => {
+            $location.path(path);
+
+            $rootScope.$digest();
+
+            resolveVersions(done);
         });
     });
 

--- a/src/api/route/version.js
+++ b/src/api/route/version.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const _ = require('lodash');
+
+module.exports.list = async (req, res) => {
+    const notes = await req.note.versions();
+    res.json(_.invokeMap(notes, 'expose'));
+};
+
+module.exports.get = async (req, res) => {
+    console.log(req.version);
+    res.json(req.version.expose());
+};

--- a/src/api/route/version.js
+++ b/src/api/route/version.js
@@ -7,7 +7,7 @@ module.exports.list = async (req, res) => {
     res.json(_.invokeMap(notes, 'expose'));
 };
 
-module.exports.get = async (req, res) => {
+/* module.exports.get = async (req, res) => {
     console.log(req.version);
     res.json(req.version.expose());
-};
+}; */

--- a/src/api/router/index.js
+++ b/src/api/router/index.js
@@ -50,6 +50,17 @@ function setupRoutesWithRequiredAuthentication(router) {
         '/notes/:noteId',
         route.note.delete
     );
+
+    //Version
+    router.get(
+        '/notes/:noteId/versions',
+        route.version.list
+    );
+    router.get(
+        '/notes/:noteId/versions/:versionId',
+        apiMiddleware.jsonParser,
+        route.version.get
+    );
 }
 
 function setup(router) {

--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const domain = require('../domain');
 
 class Note {
     constructor(note) {
@@ -11,23 +12,49 @@ class Note {
         return this._note.id;
     }
 
+    get version() {
+        return this._note.version;
+    }
+
     expose() {
         return _.pick(this._note, [
             'id',
             'subject',
             'body',
+            'version',
             'updatedAt',
         ]);
     }
 
     async update(body) {
+        await this.createVersion(this._note.subject, body, this._note.version);
         await this._note.update({
             body,
+            version: this._note.version + 1
         });
     }
 
     async delete() {
         await this._note.destroy();
+    }
+
+    async versions() {
+        const versions = await this._note.getVersions({
+            order: [
+                ['version', 'DESC']
+            ],
+        });
+        return _.map(versions, version => new domain.Version(version));
+    }
+
+    async createVersion(subject, body, prevVersion) {
+        const version = await this._note.createVersion({
+            subject,
+            body,
+            version: prevVersion
+        });
+
+        return new domain.Version(version);
     }
 }
 

--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -27,7 +27,7 @@ class Note {
     }
 
     async update(body) {
-        await this.createVersion(this._note.subject, body, this._note.version);
+        await this.createVersion(this._note.subject, this._note.body, this._note.version);
         await this._note.update({
             body,
             version: this._note.version + 1

--- a/src/domain/version.js
+++ b/src/domain/version.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const _ = require('lodash');
+
+class Version {
+    constructor(version) {
+        this._version = version;
+    }
+
+    get id() {
+        return this._version.id;
+    }
+
+    expose() {
+        return _.pick(this._version, [
+            'id',
+            'subject',
+            'body',
+            'version',
+            'updatedAt',
+        ]);
+    }
+}
+
+module.exports = Version;

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -8,14 +8,18 @@ const sequelize = new Sequelize(config.postgresql.url, {
 
 const User = require('./user');
 const Note = require('./note');
+const Version = require('./version');
 const userNoteAssociation = require('./userNote');
+const noteVersionAssociation = require('./noteVersion');
 
 const models = {
     sequelize,
     User: User.define(sequelize),
     Note: Note.define(sequelize),
+    Version: Version.define(sequelize),
 };
 
 userNoteAssociation.define(models);
+noteVersionAssociation.define(models);
 
 module.exports = models;

--- a/src/model/noteVersion.js
+++ b/src/model/noteVersion.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports.define = models => {
+    models.Note.hasMany(models.Version, {
+        foreignKey: {
+            name: 'noteId',
+            allowNull: false
+        },
+        as: 'versions',
+        onUpdate: 'RESTRICT',
+        onDelete: 'CASCADE'
+    });
+};

--- a/src/model/version.js
+++ b/src/model/version.js
@@ -3,7 +3,7 @@
 const Sequelize = require('sequelize');
 
 module.exports.define = sequelize => {
-    return sequelize.define('Note', {
+    return sequelize.define('Version', {
         id: {
             type: Sequelize.INTEGER,
             allowNull: false,
@@ -26,15 +26,14 @@ module.exports.define = sequelize => {
         },
         version: {
             type: Sequelize.INTEGER,
-            allowNull: false,
-            defaultValue: 1
+            allowNull: false
         }
     }, {
         indexes: [
             {
-                name: 'Notes_user_id',
+                name: 'Notes_version_id',
                 unique: true,
-                fields: ['userId', 'id']
+                fields: ['noteId', 'id']
             },
         ],
     });

--- a/test/api/route/version.test.js
+++ b/test/api/route/version.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+require('should');
+const sinon = require('sinon');
+const route = require('../../../src/api/route');
+
+describe('Tests for api route note', () => {
+    let req;
+    let res;
+    let note;
+    let version;
+
+    beforeEach(() => {
+        req = {};
+        res = {
+            json: sinon.spy(),
+            sendStatus: sinon.spy(),
+        };
+
+        version = {
+            expose: sinon.stub().returns('exposedVersion')
+        };
+
+        note = {
+            expose: sinon.stub().returns('exposedNote'),
+            update: sinon.stub().resolves(),
+            delete: sinon.stub().resolves(),
+            createVersion: sinon.stub().resolves(version),
+            versions: sinon.stub().resolves([
+                version,
+                version
+            ])
+        };
+
+    });
+
+    describe('list', () => {
+        it('should json the list of exposed versions', async () => {
+
+            req.note = note;
+
+            await route.version.list(req, res);
+            req.note.versions.calledWithExactly().should.be.true();
+            res.json.calledWithExactly([
+                'exposedVersion',
+                'exposedVersion'
+            ]).should.be.true();
+        });
+    });
+
+    describe('get', () => {
+        it('should json the exposed version', () => {
+            req.version = version;
+
+            route.version.get(req, res);
+
+            res.json.calledWithExactly('exposedVersion').should.be.true();
+        });
+    });
+
+});

--- a/test/api/route/version.test.js
+++ b/test/api/route/version.test.js
@@ -22,10 +22,10 @@ describe('Tests for api route note', () => {
         };
 
         note = {
-            expose: sinon.stub().returns('exposedNote'),
+            /* expose: sinon.stub().returns('exposedNote'),
             update: sinon.stub().resolves(),
             delete: sinon.stub().resolves(),
-            createVersion: sinon.stub().resolves(version),
+            createVersion: sinon.stub().resolves(version), */
             versions: sinon.stub().resolves([
                 version,
                 version
@@ -48,7 +48,7 @@ describe('Tests for api route note', () => {
         });
     });
 
-    describe('get', () => {
+    /* describe('get', () => {
         it('should json the exposed version', () => {
             req.version = version;
 
@@ -56,6 +56,6 @@ describe('Tests for api route note', () => {
 
             res.json.calledWithExactly('exposedVersion').should.be.true();
         });
-    });
+    }); */
 
 });

--- a/test/api/router.test.js
+++ b/test/api/router.test.js
@@ -39,7 +39,7 @@ describe('Tests for api router', () => {
         });
 
         it('should setup the router', () => {
-            router.get.callCount.should.equal(3);
+            router.get.callCount.should.equal(5);
             router.post.callCount.should.equal(2);
             router.put.callCount.should.equal(1);
             router.delete.callCount.should.equal(2);
@@ -94,6 +94,17 @@ describe('Tests for api router', () => {
             router.delete.calledWithExactly(
                 '/notes/:noteId',
                 route.note.delete
+            ).should.be.true();
+
+            //Version
+            router.get.calledWithExactly(
+                '/notes/:noteId/versions',
+                route.version.list
+            ).should.be.true();
+            router.get.calledWithExactly(
+                '/notes/:noteId/versions/:versionId',
+                apiMiddleware.jsonParser,
+                route.version.get
             ).should.be.true();
         });
     });

--- a/test/domain/note.test.js
+++ b/test/domain/note.test.js
@@ -33,24 +33,25 @@ describe('Tests for domain Note', () => {
         });
 
         describe('expose', () => {
-            it('should expose the id, subject, body and updatedAt of the note', () => {
+            it('should expose the id, subject, version, body and updatedAt of the note', () => {
                 domainNote.expose().should.match({
                     id: noteId,
                     subject: 'some subject',
                     body: 'some body',
+                    version: 1,
                     updatedAt: _.isDate,
                 });
             });
         });
 
         describe('update', () => {
-            it('should update the body of the note', async () => {
+            it('should update the body and version of the note', async () => {
                 await domainNote.update('new body');
-
                 domainNote.expose().should.match({
                     id: noteId,
                     subject: 'some subject',
                     body: 'new body',
+                    version: 2,
                     updatedAt: _.isDate,
                 });
             });
@@ -60,6 +61,15 @@ describe('Tests for domain Note', () => {
                     subject: 'new subject',
                     body: 'updated body'
                 }).should.be.rejectedWith(model.sequelize.ValidationError);
+            });
+
+        });
+
+        describe('versions', () => {
+            it('should retrieve all the versions of the note', async () => {
+                await domainNote.update('new body');
+                const versions = await domainNote.versions();
+                versions.length.should.be.equal(1);
             });
         });
 

--- a/test/domain/version.test.js
+++ b/test/domain/version.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const _ = require('lodash');
+require('should');
+const domain = require('../../src/domain');
+const model = require('../../src/model');
+
+describe('Tests for domain Version', () => {
+    let noteId;
+    let modelUser;
+    let domainNote;
+    let version;
+
+    beforeEach(async () => {
+        await model.sequelize.sync({
+            force: true
+        });
+
+        modelUser = await model.User.createUser('user1', 'password1');
+
+        const note = await modelUser.createNote({
+            subject: 'some subject',
+            body: 'some body',
+        });
+        noteId = note.id;
+        domainNote = new domain.Note(note);
+        version = await domainNote.createVersion('new subject', 'new body', 1);
+    });
+
+    describe('instance method', () => {
+        describe('getters', () => {
+            it('should get the id', () => {
+                version.id.should.equal(noteId);
+            });
+        });
+
+        describe('expose', () => {
+            it('should expose the id, subject, version, body and updatedAt of the current note version', () => {
+                version.expose().should.match({
+                    id: 1,
+                    subject: 'new subject',
+                    body: 'new body',
+                    version: 1,
+                    updatedAt: _.isDate,
+                });
+            });
+        });
+
+    });
+});


### PR DESCRIPTION
This feature adds a simple versioning for a note. This feature enables users to see previous versions of a selected note (including its contents) and only allow the editing of the latest version.

Versions table was added to store previous versions of a note. The notes table has an added version column indicating the latest version. On top of this, a version API was added to fetch the versions of a selected note when viewing its details. This structure takes advantage of the existing functionalities of a note instance and minimizes code refactoring. This also ensures that the app does not load unnecessary data. For instance, loading of notes on the list page does not load the version of each note since all the needed details are already present on the note itself. Loading of a note's versions will only happen when a note is viewed in detail.

